### PR TITLE
Allow user to place config file in their own folder

### DIFF
--- a/init.php
+++ b/init.php
@@ -28,7 +28,7 @@ define('DHL_API_DIR', __DIR__ . '/');
 require_once(DHL_API_DIR . 'vendor/autoloadManager/autoloadManager.php');
 
 // Load adequate configuration file based on the APPLICATION_ENVIRONMENT 
-if ($applicationEnvironment = getenv('APPLICATION_ENVIRONMENT')) 
+if ($applicationEnvironment = getenv('APPLICATION_ENVIRONMENT'))
 {
     $configFilename = 'config-' . $applicationEnvironment . '.php';
 }
@@ -37,7 +37,12 @@ else
     $configFilename = 'config.php';
 }
 
-$config = require(DHL_API_DIR . 'conf/' . $configFilename);
+//Allow to place the config file anywhere in project
+if (! defined('DHL_CONF_API_DIR')) {
+    define('DHL_CONF_API_DIR', __DIR__ . '/');
+}
+
+$config = require(DHL_CONF_API_DIR . 'conf/' . $configFilename);
 $scanOption = isset($config['autoloader']['scanOption']) ? $config['autoloader']['scanOption'] : autoloadManager::SCAN_ONCE;
 $autoloadDir = isset($config['autoloader']['dir']) ? $config['autoloader']['dir'] : sys_get_temp_dir() . '/dhl-api-autoload.php';
 


### PR DESCRIPTION
Adding a constant DHL_CONF_API_DIR which will allow user to place the config folder anywhere in their project.