### PR TITLE
Fix Service uses and BarCodes DataType name

### DIFF
--- a/DHL/Entity/GB/ShipmentResponse.php
+++ b/DHL/Entity/GB/ShipmentResponse.php
@@ -197,8 +197,8 @@ class ShipmentResponse extends Base
             'subobject' => true,
             'multivalues' => true,
         ), 
-        'Barcodes' => array(
-            'type' => 'Barcodes',
+        'BarCodes' => array(
+            'type' => 'BarCodes',
             'required' => false,
             'subobject' => true,
             'multivalues' => false,

--- a/DHL/Service.php
+++ b/DHL/Service.php
@@ -23,8 +23,8 @@
  */
 
 namespace DHL;
-use DHL\Datatype\Entity\GB\ShipmentRequest;
-use DHL\Datatype\Entity\GB\ShipmentResponse;
+use DHL\Entity\GB\ShipmentRequest;
+use DHL\Entity\GB\ShipmentResponse;
 use DHL\Client\Web as WebserviceClient;
 
 /**


### PR DESCRIPTION
The BarCodes class name is written incorrectly, producing fatal errors on Class not found.
Also there're no such directory as `DHL\Datatype\Entity`, only `DHL\Entity`, which renders service unusable and throws same Class not found error.
This might not be the issue for Windows hosts, but for Linux ones it surely is.