### PR TITLE
Commercial Invoice related fields added and changed some parameters which are giving error in DHL api reponse.

### DIFF
--- a/DHL/Datatype/AM/Consignee.php
+++ b/DHL/Datatype/AM/Consignee.php
@@ -49,7 +49,7 @@ class Consignee extends Base
             'maxLength' => '35',
         ),
         'AddressLine' => array(
-            'type' => 'AddressLine',
+            'type' => 'string',
             'required' => false,
             'subobject' => false,
             'comment' => 'Address Line',

--- a/DHL/Datatype/AM/Consignee.php
+++ b/DHL/Datatype/AM/Consignee.php
@@ -22,7 +22,7 @@
  * @version     0.1
  */
 
-namespace DHL\Datatype\AM; 
+namespace DHL\Datatype\AM;
 use DHL\Datatype\Base;
 
 /**
@@ -47,67 +47,68 @@ class Consignee extends Base
             'subobject' => false,
             'comment' => 'Name of company / business',
             'maxLength' => '35',
-        ), 
+        ),
         'AddressLine' => array(
             'type' => 'AddressLine',
             'required' => false,
             'subobject' => false,
             'comment' => 'Address Line',
-            'maxLength' => '35',
-        ), 
+            'maxLength' => '45',
+            'multivalues' => true,
+        ),
         'City' => array(
             'type' => 'City',
             'required' => false,
             'subobject' => false,
             'comment' => 'City name',
             'maxLength' => '35',
-        ), 
+        ),
         'Division' => array(
             'type' => 'Division',
             'required' => false,
             'subobject' => false,
             'comment' => 'Division (e.g. state, prefecture, etc.) name',
             'maxLength' => '35',
-        ), 
+        ),
         'DivisionCode' => array(
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'PostalCode' => array(
             'type' => 'PostalCode',
             'required' => false,
             'subobject' => false,
             'comment' => 'Full postal/zip code for address',
-        ), 
+        ),
         'CountryCode' => array(
             'type' => 'CountryCode',
             'required' => false,
             'subobject' => false,
             'comment' => 'ISO country codes',
             'length' => '2',
-        ), 
+        ),
         'CountryName' => array(
             'type' => 'CountryName',
             'required' => false,
             'subobject' => false,
             'comment' => 'ISO country name',
             'maxLength' => '35',
-        ), 
+        ),
         'FederalTaxId' => array(
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'StateTaxId' => array(
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'Contact' => array(
             'type' => 'Contact',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
     );
 }

--- a/DHL/Datatype/AM/Contact.php
+++ b/DHL/Datatype/AM/Contact.php
@@ -22,7 +22,7 @@
  * @version     0.1
  */
 
-namespace DHL\Datatype\AM; 
+namespace DHL\Datatype\AM;
 use DHL\Datatype\Base;
 
 /**
@@ -47,37 +47,37 @@ class Contact extends Base
             'subobject' => false,
             'comment' => 'Name',
             'maxLength' => '35',
-        ), 
+        ),
         'PhoneNumber' => array(
             'type' => 'PhoneNumber',
             'required' => false,
             'subobject' => false,
             'comment' => 'Phone Number',
-        ), 
+        ),
         'PhoneExtension' => array(
             'type' => 'PhoneExtension',
             'required' => false,
             'subobject' => false,
             'comment' => '',
             'maxLength' => '5',
-        ), 
+        ),
         'FaxNumber' => array(
             'type' => 'PhoneNumber',
             'required' => false,
             'subobject' => false,
             'comment' => 'Phone Number',
-        ), 
+        ),
         'Telex' => array(
             'type' => 'Telex',
             'required' => false,
             'subobject' => false,
             'comment' => 'Telex number and answer back code',
             'maxLength' => '25',
-        ), 
+        ),
         'Email' => array(
             'type' => 'Email',
             'required' => false,
-            'subobject' => true,
-        ), 
+            'subobject' => false,
+        ),
     );
 }

--- a/DHL/Datatype/AM/ExportDeclaration.php
+++ b/DHL/Datatype/AM/ExportDeclaration.php
@@ -108,13 +108,6 @@ class ExportDeclaration extends Base
             'required' => false,
             'subobject' => false,
         ),
-        'ExportLineItem' => array(
-            'type' => 'ExportLineItem',
-            'required' => false,
-            'subobject' => true,
-            'multivalues' => true,
-            'disableParentNode' => true,
-        ),
         'InvoiceNumber' => array(
             'type' => 'string',
             'required' => false,
@@ -139,6 +132,13 @@ class ExportDeclaration extends Base
             'type' => 'number',
             'required' => false,
             'subobject' => false,
+        ),
+        'ExportLineItem' => array(
+            'type' => 'ExportLineItem',
+            'required' => false,
+            'subobject' => true,
+            'multivalues' => true,
+            'disableParentNode' => true,
         ),
     );
 }

--- a/DHL/Datatype/AM/ExportDeclaration.php
+++ b/DHL/Datatype/AM/ExportDeclaration.php
@@ -22,7 +22,7 @@
  * @version     0.1
  */
 
-namespace DHL\Datatype\AM; 
+namespace DHL\Datatype\AM;
 use DHL\Datatype\Base;
 
 /**
@@ -45,7 +45,7 @@ class ExportDeclaration extends Base
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'IsPartiesRelation' => array(
             'type' => 'YesNo',
             'required' => false,
@@ -53,33 +53,33 @@ class ExportDeclaration extends Base
             'comment' => 'Boolean flag',
             'length' => '1',
             'enumeration' => 'Y,N',
-        ), 
+        ),
         'ECCN' => array(
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'SignatureName' => array(
             'type' => 'SignatureName',
             'required' => false,
             'subobject' => false,
             'comment' => 'Signature name',
             'maxLength' => '35',
-        ), 
+        ),
         'SignatureTitle' => array(
             'type' => 'SignatureTitle',
             'required' => false,
             'subobject' => false,
             'comment' => 'Signature title',
             'maxLength' => '35',
-        ), 
+        ),
         'ExportReason' => array(
             'type' => 'ExportReason',
             'required' => false,
             'subobject' => false,
             'comment' => 'Export reason',
             'length' => '1',
-        ), 
+        ),
         'ExportReasonCode' => array(
             'type' => 'ExportReasonCode',
             'required' => false,
@@ -87,14 +87,14 @@ class ExportDeclaration extends Base
             'comment' => 'Export reason code (P:Permanent, T:Temporary, R:Re-Export)',
             'length' => '1',
             'enumeration' => 'P,T,R',
-        ), 
+        ),
         'SedNumber' => array(
             'type' => 'SEDNumber',
             'required' => false,
             'subobject' => false,
             'comment' => '',
             'enumeration' => 'FTSR,XTN,SAS',
-        ), 
+        ),
         'SedNumberType' => array(
             'type' => 'SEDNumberType',
             'required' => false,
@@ -102,16 +102,42 @@ class ExportDeclaration extends Base
             'comment' => '',
             'length' => '1',
             'enumeration' => 'F,X,S',
-        ), 
+        ),
         'MxStateCode' => array(
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'ExportLineItem' => array(
             'type' => 'ExportLineItem',
             'required' => false,
             'subobject' => true,
-        ), 
+            'multivalues' => true,
+        ),
+        'InvoiceNumber' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+        ),
+        'InvoiceDate' => array(
+            'type' => 'date',
+            'required' => false,
+            'subobject' => false,
+        ),
+        'OtherCharges1' => array(
+            'type' => 'number',
+            'required' => false,
+            'subobject' => false,
+        ),
+        'OtherCharges2' => array(
+            'type' => 'number',
+            'required' => false,
+            'subobject' => false,
+        ),
+        'OtherCharges3' => array(
+            'type' => 'number',
+            'required' => false,
+            'subobject' => false,
+        ),
     );
 }

--- a/DHL/Datatype/AM/ExportDeclaration.php
+++ b/DHL/Datatype/AM/ExportDeclaration.php
@@ -113,6 +113,7 @@ class ExportDeclaration extends Base
             'required' => false,
             'subobject' => true,
             'multivalues' => true,
+            'disableParentNode' => true,
         ),
         'InvoiceNumber' => array(
             'type' => 'string',

--- a/DHL/Datatype/AM/ExportLineItem.php
+++ b/DHL/Datatype/AM/ExportLineItem.php
@@ -22,7 +22,7 @@
  * @version     0.1
  */
 
-namespace DHL\Datatype\AM; 
+namespace DHL\Datatype\AM;
 use DHL\Datatype\Base;
 
 /**
@@ -48,26 +48,26 @@ class ExportLineItem extends Base
             'comment' => '',
             'minInclusive' => '1',
             'maxInclusive' => '200',
-        ), 
+        ),
         'Quantity' => array(
             'type' => 'Quantity',
             'required' => false,
             'subobject' => false,
             'comment' => 'Quantity',
             'maxInclusive' => '32000',
-        ), 
+        ),
         'QuantityUnit' => array(
             'type' => 'QuantityUnit',
             'required' => false,
             'subobject' => false,
             'comment' => 'Quantity unit of measure (tens, hundreds, thousands, etc.)',
             'maxLength' => '8',
-        ), 
+        ),
         'Description' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'Value' => array(
             'type' => 'Money',
             'required' => false,
@@ -75,7 +75,7 @@ class ExportLineItem extends Base
             'comment' => 'Monetary amount (with 2 decimal precision)',
             'minInclusive' => '0.00',
             'maxInclusive' => '9999999999.99',
-        ), 
+        ),
         'IsDomestic' => array(
             'type' => 'YesNo',
             'required' => false,
@@ -83,7 +83,7 @@ class ExportLineItem extends Base
             'comment' => 'Boolean flag',
             'length' => '1',
             'enumeration' => 'Y,N',
-        ), 
+        ),
         'CommodityCode' => array(
             'type' => 'CommodityCode',
             'required' => false,
@@ -91,35 +91,50 @@ class ExportLineItem extends Base
             'comment' => 'Commodity codes for shipment type',
             'minLength' => '1',
             'maxLength' => '20',
-        ), 
+        ),
         'ScheduleB' => array(
             'type' => 'ScheduleB',
             'required' => false,
             'subobject' => false,
             'comment' => 'Schedule B numner',
             'maxLength' => '15',
-        ), 
+        ),
         'ECCN' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'Weight' => array(
-            'type' => '',
+            'type' => 'WeightSeg',
             'required' => false,
-            'subobject' => false,
-        ), 
+            'subobject' => true,
+        ),
+        'GrossWeight' => array(
+            'type' => 'WeightSeg',
+            'required' => false,
+            'subobject' => true,
+        ),
         'License' => array(
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'LicenseSymbol' => array(
             'type' => 'LicenseNumber',
             'required' => false,
             'subobject' => false,
             'comment' => 'Export license number',
             'maxLength' => '16',
-        ), 
+        ),
+        'ManufactureCountryCode' => array(
+            'type' => 'CountryCode',
+            'required' => false,
+            'subobject' => false,
+        ),
+        'ManufactureCountryName' => array(
+            'type' => 'CountryName',
+            'required' => false,
+            'subobject' => false,
+        ),
     );
 }

--- a/DHL/Datatype/AM/ExportLineItem.php
+++ b/DHL/Datatype/AM/ExportLineItem.php
@@ -105,12 +105,12 @@ class ExportLineItem extends Base
             'subobject' => false,
         ),
         'Weight' => array(
-            'type' => 'WeightSeg',
+            'type' => 'Weight',
             'required' => false,
             'subobject' => true,
         ),
         'GrossWeight' => array(
-            'type' => 'WeightSeg',
+            'type' => 'GrossWeight',
             'required' => false,
             'subobject' => true,
         ),

--- a/DHL/Datatype/AM/GrossWeight.php
+++ b/DHL/Datatype/AM/GrossWeight.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Note : Code is released under the GNU LGPL
+ *
+ * Please do not change the header of this file
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU Lesser General Public License for more details.
+ */
+
+/**
+ * File:        WeightSeg.php
+ * Project:     DHL API
+ *
+ * @author      Al-Fallouji Bashar
+ * @version     0.1
+ */
+
+namespace DHL\Datatype\AM;
+use DHL\Datatype\Base;
+
+/**
+ * WeightSeg Request model for DHL API
+ */
+class GrossWeight extends Base
+{
+    /**
+     * Is this object a subobject
+     * @var boolean
+     */
+    protected $_isSubobject = true;
+
+    /**
+     * Parameters of the datatype
+     * @var array
+     */
+    protected $_params = array(
+        'Weight' => array(
+            'type' => 'Weight',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'Weight of piece or shipment',
+            'fractionDigits' => '1',
+            'maxInclusive' => '999999.9',
+            'totalDigits' => '7',
+        ),
+        'WeightUnit' => array(
+            'type' => 'WeightUnit',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'Unit of weight measurement (L:Pounds)',
+            'length' => '1',
+            'enumeration' => 'K,L',
+        ),
+    );
+}

--- a/DHL/Datatype/AM/MetaData.php
+++ b/DHL/Datatype/AM/MetaData.php
@@ -15,7 +15,7 @@
  */
 
 /**
- * File:        Request.php
+ * File:        MetaData.php
  * Project:     DHL API
  *
  * @author      Al-Fallouji Bashar
@@ -26,9 +26,9 @@ namespace DHL\Datatype\AM;
 use DHL\Datatype\Base;
 
 /**
- * Request Request model for DHL API
+ * MetaData Request model for DHL API
  */
-class Request extends Base
+class MetaData extends Base
 {
     /**
      * Is this object a subobject
@@ -41,15 +41,15 @@ class Request extends Base
      * @var array
      */
     protected $_params = array(
-        'ServiceHeader' => array(
-            'type' => 'ServiceHeader',
-            'required' => false,
-            'subobject' => true,
+        'SoftwareName' => array(
+            'type' => 'string',
+            'required' => true,
+            'subobject' => false,
         ),
-        'MetaData' => array(
-            'type' => 'MetaData',
-            'required' => false,
-            'subobject' => true,
+        'SoftwareVersion' => array(
+            'type' => 'string',
+            'required' => true,
+            'subobject' => false,
         ),
     );
 }

--- a/DHL/Datatype/AM/Pickup.php
+++ b/DHL/Datatype/AM/Pickup.php
@@ -1,0 +1,90 @@
+<?php
+
+
+    namespace DHL\Datatype\AM;
+    use DHL\Datatype\Base;
+
+
+    class Pickup extends Base
+    {
+        /**
+         * Is this object a subobject
+         * @var boolean
+         */
+        protected $_isSubobject = true;
+
+        /**
+         * Parameters of the datatype
+         * @var array
+         */
+        protected $_params = array(
+            'PickupDate' => array(
+                'type' => 'date',
+                'required' => true,
+                'subobject' => false,
+            ),
+            'PickupTypeCode' => array(
+                'type' => 'string',
+                'required' => true,
+                'subobject' => false,
+                'length' => '1',
+                'enumeration' => 'S,A'
+            ),
+            'ReadyByTime' => array(
+                'type' => 'string', //'TimeHM',
+                'required' => true,
+                'subobject' => false,
+                'length' => '5',
+            ),
+            'CloseTime' => array(
+                'type' => 'string', //'TimeHM',
+                'required' => true,
+                'subobject' => false,
+                'length' => '5',
+            ),
+            'AfterHoursClosingTime' => array(
+                'type' => 'string', //'TimeHM',
+                'required' => false,
+                'subobject' => false,
+                'length' => '5',
+            ),
+            'AfterHoursLocation' => array(
+                'type' => 'string',
+                'required' => false,
+                'subobject' => false,
+                'maxLength' => 35,
+            ),
+            'Pieces' => array(
+                'type' => 'number',
+                'required' => false,
+                'subobject' => false,
+                'minInclusive' => 1,
+                'maxInclusive' => 999,
+            ),
+            'RemotePickupFlag' => array(
+                'type' => 'YesNo',
+                'required' => false,
+                'subobject' => false,
+                'comment' => 'Boolean flag',
+                'length' => '1',
+                'enumeration' => 'Y,N',
+            ),
+            'weight' => array(
+                'type' => 'Weight',
+                'required' => false,
+                'subobject' => true,
+            ),
+            'SpecialInstructions' => array(
+                'type' => 'SpecialInstructions',
+                'required' => false,
+                'subobject' => false,
+                'maxLength' =>80
+            ),
+            'Remarks' => array(
+                'type' => 'string',
+                'required' => false,
+                'subobject' => false,
+                'maxLength' => 2048,
+            ),
+        );
+    }

--- a/DHL/Datatype/AM/PickupContact.php
+++ b/DHL/Datatype/AM/PickupContact.php
@@ -1,0 +1,57 @@
+<?php
+    /**
+     * Note : Code is released under the GNU LGPL
+     *
+     * Please do not change the header of this file
+     *
+     * This library is free software; you can redistribute it and/or modify it under the terms of the GNU
+     * Lesser General Public License as published by the Free Software Foundation; either version 2 of
+     * the License, or (at your option) any later version.
+     *
+     * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+     * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+     *
+     * See the GNU Lesser General Public License for more details.
+     */
+
+
+    namespace DHL\Datatype\AM;
+
+    use DHL\Datatype\Base;
+
+    class PickupContact extends Base
+    {
+        /**
+         * Is this object a subobject
+         * @var boolean
+         */
+        protected $_isSubobject = true;
+
+        /**
+         * Parameters of the datatype
+         * @var array
+         */
+        protected $_params = array(
+            'PersonName' => array(
+                'type' => 'string',
+                'required' => true,
+                'subobject' => false,
+                'comment' => 'Name',
+                'maxLength' => '35',
+            ),
+            'Phone' => array(
+                'type' => 'string',
+                'required' => true  ,
+                'subobject' => false,
+                'comment' => 'Phone Number',
+                'maxLength' => '25',
+            ),
+            'PhoneExtension' => array(
+                'type' => 'string',
+                'required' => false,
+                'subobject' => false,
+                'comment' => '',
+                'maxLength' => '5',
+            ),
+        );
+    }

--- a/DHL/Datatype/AM/PickupPlace.php
+++ b/DHL/Datatype/AM/PickupPlace.php
@@ -15,10 +15,10 @@
  */
 
 /**
- * File:        Place.php
+ * File:        PickupPlace.php
  * Project:     DHL API
  *
- * @author      Al-Fallouji Bashar
+ * @author      Mutahhar
  * @version     0.1
  */
 
@@ -26,9 +26,9 @@ namespace DHL\Datatype\AM;
 use DHL\Datatype\Base;
 
 /**
- * Place Request model for DHL API
+ * PickupPlace Request model for DHL API
  */
-class Place extends Base
+class PickupPlace extends Base
 {
     /**
      * Is this object a subobject
@@ -37,13 +37,19 @@ class Place extends Base
     protected $_isSubobject = true;
 
     /**
+     * Parent node name of the object
+     * @var string
+     */
+    protected $_xmlNodeName = 'Place';
+
+    /**
      * Parameters of the datatype
      * @var array
      */
     protected $_params = array(
-        'ResidenceOrBusiness' => array(
-            'type' => 'ResidenceOrBusiness',
-            'required' => false,
+        'LocationType' => array(
+            'type' => 'string',
+            'required' => true,
             'subobject' => false,
             'comment' => 'Identifies if a location is a business, residence, or both (B:Business, R:Residence, C:Business Residence)',
             'length' => '1',
@@ -51,49 +57,81 @@ class Place extends Base
         ),
         'CompanyName' => array(
             'type' => 'CompanyNameValidator',
-            'required' => false,
+            'required' => true,
             'subobject' => false,
             'comment' => 'Name of company / business',
-            'maxLength' => '35',
+            'maxLength' => '45',
         ),
-        'AddressLine' => array(
-            'type' => 'AddressLine',
+        'Address1' => array(
+            'type' => 'string',
+            'required' => true,
+            'subobject' => false,
+            'comment' => 'Address Line',
+            'maxLength' => '45',
+        ),
+        'Address2' => array(
+            'type' => 'string',
             'required' => false,
             'subobject' => false,
             'comment' => 'Address Line',
-            'maxLength' => '35',
+            'maxLength' => '45',
+        ),
+        'Address3' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'Address Line',
+            'maxLength' => '45',
+        ),
+        'PackageLocation' => array(
+            'type' => 'string',
+            'required' => true,
+            'subobject' => false,
+            'comment' => 'Address Line',
+            'maxLength' => '45',
         ),
         'City' => array(
             'type' => 'City',
-            'required' => false,
+            'required' => true,
             'subobject' => false,
             'comment' => 'City name',
-            'maxLength' => '35',
+            'maxLength' => '45',
+        ),
+        'StateCode' => array(
+            'type' => 'StateCode',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'State',
+            'maxLength' => '45',
+        ),
+        'DivisionName' => array(
+            'type' => 'Division',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'State',
+            'maxLength' => '45',
         ),
         'CountryCode' => array(
             'type' => 'CountryCode',
-            'required' => false,
+            'required' => true,
             'subobject' => false,
             'comment' => 'ISO country codes',
             'length' => '2',
         ),
-        'DivisionCode' => array(
-            'type' => 'StateCode',
-            'required' => false,
-            'subobject' => false,
-            'comment' => 'Division (state) code.',
-            'maxLength' => '2',
-            'minLength' => '2',
-        ),
-        'Division' => array(
-            'type' => 'State',
-            'required' => false,
-            'subobject' => false,
-            'comment' => 'State',
-            'maxLength' => '35',
-        ),
         'PostalCode' => array(
             'type' => 'PostalCode',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'Full postal/zip code for address',
+        ),
+        'RouteCode' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'Full postal/zip code for address',
+        ),
+        'Suburb' => array(
+            'type' => 'Suburb',
             'required' => false,
             'subobject' => false,
             'comment' => 'Full postal/zip code for address',

--- a/DHL/Datatype/AM/Requestor.php
+++ b/DHL/Datatype/AM/Requestor.php
@@ -1,0 +1,108 @@
+<?php
+    /**
+     * Note : Code is released under the GNU LGPL
+     *
+     * Please do not change the header of this file
+     *
+     * This library is free software; you can redistribute it and/or modify it under the terms of the GNU
+     * Lesser General Public License as published by the Free Software Foundation; either version 2 of
+     * the License, or (at your option) any later version.
+     *
+     * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+     * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+     *
+     * See the GNU Lesser General Public License for more details.
+     */
+
+
+    namespace DHL\Datatype\AM;
+
+    use DHL\Datatype\Base;
+
+    class Requestor extends Base
+    {
+        /**
+         * Is this object a subobject
+         * @var boolean
+         */
+        protected $_isSubobject = true;
+
+        /**
+         * Parameters of the datatype
+         * @var array
+         */
+        protected $_params = array(
+            'AccountType' => array(
+                'type' => 'AccountType',
+                'required' => true,
+                'subobject' => false,
+            ),
+            'AccountNumber' => array(
+                'type' => 'AccountNumber',
+                'required' => true,
+                'subobject' => false,
+                'maxLength' => '12',
+            ),
+            'RequestorContact' => array(
+                'type' => 'RequestorContact',
+                'required' => false,
+                'subobject' => true,
+            ),
+            'CompanyName' => array(
+                'type' => 'CompanyNameValidator',
+                'required' => false,
+                'subobject' => false,
+                'comment' => 'Name of company / business',
+                'maxLength' => '60',
+                'minLength' => '2',
+            ),
+            'Address1' => array(
+                'type' => 'string',
+                'required' => true,
+                'subobject' => false,
+                'comment' => 'Address Line',
+                'maxLength' => '45',
+            ),
+            'Address2' => array(
+                'type' => 'string',
+                'required' => false,
+                'subobject' => false,
+                'comment' => 'Address Line',
+                'maxLength' => '45',
+            ),
+            'Address3' => array(
+                'type' => 'string',
+                'required' => false,
+                'subobject' => false,
+                'comment' => 'Address Line',
+                'maxLength' => '45',
+            ),
+            'City' => array(
+                'type' => 'City',
+                'required' => true,
+                'subobject' => false,
+                'comment' => 'City name',
+                'maxLength' => '35',
+            ),
+            'CountryCode' => array(
+                'type' => 'CountryCode',
+                'required' => true,
+                'subobject' => false,
+                'comment' => 'ISO country codes',
+                'length' => '2',
+            ),
+            'DivisionName' => array(
+                'type' => 'Division',
+                'required' => false,
+                'subobject' => false,
+                'comment' => 'State',
+                'maxLength' => '35',
+            ),
+            'PostalCode' => array(
+                'type' => 'PostalCode',
+                'required' => false,
+                'subobject' => false,
+                'comment' => 'Full postal/zip code for address',
+            ),
+        );
+    }

--- a/DHL/Datatype/AM/RequestorContact.php
+++ b/DHL/Datatype/AM/RequestorContact.php
@@ -1,0 +1,57 @@
+<?php
+    /**
+     * Note : Code is released under the GNU LGPL
+     *
+     * Please do not change the header of this file
+     *
+     * This library is free software; you can redistribute it and/or modify it under the terms of the GNU
+     * Lesser General Public License as published by the Free Software Foundation; either version 2 of
+     * the License, or (at your option) any later version.
+     *
+     * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+     * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+     *
+     * See the GNU Lesser General Public License for more details.
+     */
+
+
+    namespace DHL\Datatype\AM;
+
+    use DHL\Datatype\Base;
+
+    class RequestorContact extends Base
+    {
+        /**
+         * Is this object a subobject
+         * @var boolean
+         */
+        protected $_isSubobject = true;
+
+        /**
+         * Parameters of the datatype
+         * @var array
+         */
+        protected $_params = array(
+            'PersonName' => array(
+                'type' => 'string',
+                'required' => true,
+                'subobject' => false,
+                'comment' => 'Name',
+                'maxLength' => '35',
+            ),
+            'Phone' => array(
+                'type' => 'string',
+                'required' => true  ,
+                'subobject' => false,
+                'comment' => 'Phone Number',
+                'maxLength' => '25',
+            ),
+            'PhoneExtension' => array(
+                'type' => 'string',
+                'required' => false,
+                'subobject' => false,
+                'comment' => '',
+                'maxLength' => '5',
+            ),
+        );
+    }

--- a/DHL/Datatype/AM/ShipmentDetails.php
+++ b/DHL/Datatype/AM/ShipmentDetails.php
@@ -22,7 +22,7 @@
  * @version     0.1
  */
 
-namespace DHL\Datatype\AM; 
+namespace DHL\Datatype\AM;
 use DHL\Datatype\Base;
 
 /**
@@ -45,13 +45,13 @@ class ShipmentDetails extends Base
             'type' => 'positiveInteger',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'Pieces' => array(
             'type' => 'Piece',
             'required' => false,
             'subobject' => true,
             'multivalues' => true,
-        ), 
+        ),
         'Weight' => array(
             'type' => 'Weight',
             'required' => false,
@@ -60,7 +60,7 @@ class ShipmentDetails extends Base
             'fractionDigits' => '1',
             'maxInclusive' => '999999.9',
             'totalDigits' => '7',
-        ), 
+        ),
         'WeightUnit' => array(
             'type' => 'WeightUnit',
             'required' => false,
@@ -68,14 +68,14 @@ class ShipmentDetails extends Base
             'comment' => 'Unit of weight measurement (L:Pounds)',
             'length' => '1',
             'enumeration' => 'K,L',
-        ), 
+        ),
         'ProductCode' => array(
             'type' => 'ProductCode',
             'required' => false,
             'subobject' => false,
-            'comment' => 'DHL product code 
-			D : US Overnight  (>0.5 lb) and Worldwide Express Non-dutiable  (>0.5 lb) 
-			X : USA Express Envelope   (less than or  = 0.5 lb) and Worldwide Express-International Express Envelope  (less than or = 0.5 lb) 
+            'comment' => 'DHL product code
+			D : US Overnight  (>0.5 lb) and Worldwide Express Non-dutiable  (>0.5 lb)
+			X : USA Express Envelope   (less than or  = 0.5 lb) and Worldwide Express-International Express Envelope  (less than or = 0.5 lb)
 			W : Worldwide Express-Dutiable
 			Y : DHL Second Day Express . Must be Express Envelop with weight lessthan or = 0.5 lb
 			G : DHL Second Day . Weight > 0.5 lb or not an express envelop
@@ -83,14 +83,14 @@ class ShipmentDetails extends Base
             'pattern' => '([A-Z0-9])*',
             'minLength' => '1',
             'maxLength' => '4',
-        ), 
+        ),
         'GlobalProductCode' => array(
             'type' => 'ProductCode',
             'required' => false,
             'subobject' => false,
-            'comment' => 'DHL product code 
-			D : US Overnight  (>0.5 lb) and Worldwide Express Non-dutiable  (>0.5 lb) 
-			X : USA Express Envelope   (less than or  = 0.5 lb) and Worldwide Express-International Express Envelope  (less than or = 0.5 lb) 
+            'comment' => 'DHL product code
+			D : US Overnight  (>0.5 lb) and Worldwide Express Non-dutiable  (>0.5 lb)
+			X : USA Express Envelope   (less than or  = 0.5 lb) and Worldwide Express-International Express Envelope  (less than or = 0.5 lb)
 			W : Worldwide Express-Dutiable
 			Y : DHL Second Day Express . Must be Express Envelop with weight lessthan or = 0.5 lb
 			G : DHL Second Day . Weight > 0.5 lb or not an express envelop
@@ -98,7 +98,7 @@ class ShipmentDetails extends Base
             'pattern' => '([A-Z0-9])*',
             'minLength' => '1',
             'maxLength' => '4',
-        ), 
+        ),
         'LocalProductCode' => array(
             'type' => 'LocalProductCode',
             'required' => false,
@@ -106,20 +106,20 @@ class ShipmentDetails extends Base
             'comment' => '',
             'minLength' => '1',
             'maxLength' => '4',
-        ), 
+        ),
         'Date' => array(
             'type' => 'Date',
             'required' => false,
             'subobject' => false,
             'comment' => 'Date only',
-        ), 
+        ),
         'Contents' => array(
             'type' => 'ShipmentContents',
             'required' => false,
             'subobject' => false,
             'comment' => 'Shipment contents description',
             'maxLength' => '90',
-        ), 
+        ),
         'DoorTo' => array(
             'type' => 'DoorTo',
             'required' => false,
@@ -127,7 +127,7 @@ class ShipmentDetails extends Base
             'comment' => 'Defines the type of delivery service that applies to the shipment',
             'length' => '2',
             'enumeration' => 'DD,DA,AA,DC',
-        ), 
+        ),
         'DimensionUnit' => array(
             'type' => 'DimensionUnit',
             'required' => false,
@@ -135,7 +135,7 @@ class ShipmentDetails extends Base
             'comment' => 'Dimension Unit I (inches)',
             'length' => '1',
             'enumeration' => 'C,I',
-        ), 
+        ),
         'InsuredAmount' => array(
             'type' => 'Money',
             'required' => false,
@@ -143,7 +143,7 @@ class ShipmentDetails extends Base
             'comment' => 'Monetary amount (with 2 decimal precision)',
             'minInclusive' => '0.00',
             'maxInclusive' => '9999999999.99',
-        ), 
+        ),
         'PackageType' => array(
             'type' => 'PackageType',
             'required' => false,
@@ -151,7 +151,7 @@ class ShipmentDetails extends Base
             'comment' => 'Package Type (EE: DHL Express Envelope, OD:Other DHL Packaging, CP:Customer-provided.Ground shipments must choose CP)',
             'length' => '2',
             'enumeration' => 'EE,OD,CP',
-        ), 
+        ),
         'IsDutiable' => array(
             'type' => 'YesNo',
             'required' => false,
@@ -159,14 +159,14 @@ class ShipmentDetails extends Base
             'comment' => 'Boolean flag',
             'length' => '1',
             'enumeration' => 'Y,N',
-        ), 
+        ),
         'CurrencyCode' => array(
             'type' => 'CurrencyCode',
             'required' => false,
             'subobject' => false,
             'comment' => 'ISO currency code',
             'length' => '3',
-        ), 
+        ),
         'CustData' => array(
             'type' => 'CustData',
             'required' => false,
@@ -174,6 +174,6 @@ class ShipmentDetails extends Base
             'comment' => 'CustData',
             'minLength' => '1',
             'maxLength' => '100',
-        ), 
+        ),
     );
 }

--- a/DHL/Datatype/AM/ShipmentDetails.php
+++ b/DHL/Datatype/AM/ShipmentDetails.php
@@ -41,6 +41,21 @@ class ShipmentDetails extends Base
      * @var array
      */
     protected $_params = array(
+        'AccountType' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+        ),
+        'AccountNumber' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+        ),
+        'BillToAccountNumber' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+        ),
         'NumberOfPieces' => array(
             'type' => 'positiveInteger',
             'required' => false,

--- a/DHL/Datatype/AM/Shipper.php
+++ b/DHL/Datatype/AM/Shipper.php
@@ -64,7 +64,7 @@ class Shipper extends Base
             'minInclusive' => '100000000',
         ),
         'AddressLine' => array(
-            'type' => 'AddressLine',
+            'type' => 'string',
             'required' => false,
             'subobject' => false,
             'comment' => 'Address Line',

--- a/DHL/Datatype/AM/Shipper.php
+++ b/DHL/Datatype/AM/Shipper.php
@@ -22,7 +22,7 @@
  * @version     0.1
  */
 
-namespace DHL\Datatype\AM; 
+namespace DHL\Datatype\AM;
 use DHL\Datatype\Base;
 
 /**
@@ -47,14 +47,14 @@ class Shipper extends Base
             'subobject' => false,
             'comment' => 'Shipper\'s ID',
             'maxLength' => '30',
-        ), 
+        ),
         'CompanyName' => array(
             'type' => 'CompanyNameValidator',
             'required' => false,
             'subobject' => false,
             'comment' => 'Name of company / business',
             'maxLength' => '35',
-        ), 
+        ),
         'RegisteredAccount' => array(
             'type' => 'AccountNumber',
             'required' => false,
@@ -62,81 +62,81 @@ class Shipper extends Base
             'comment' => 'DHL Account Number',
             'maxInclusive' => '9999999999',
             'minInclusive' => '100000000',
-        ), 
+        ),
         'AddressLine' => array(
             'type' => 'AddressLine',
             'required' => false,
             'subobject' => false,
             'comment' => 'Address Line',
             'maxLength' => '35',
-        ), 
+        ),
         'City' => array(
             'type' => 'City',
             'required' => false,
             'subobject' => false,
             'comment' => 'City name',
             'maxLength' => '35',
-        ), 
+        ),
         'Division' => array(
             'type' => 'Division',
             'required' => false,
             'subobject' => false,
             'comment' => 'Division (e.g. state, prefecture, etc.) name',
             'maxLength' => '35',
-        ), 
+        ),
         'DivisionCode' => array(
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'PostalCode' => array(
             'type' => 'PostalCode',
             'required' => false,
             'subobject' => false,
             'comment' => 'Full postal/zip code for address',
-        ), 
+        ),
         'OriginServiceAreaCode' => array(
             'type' => 'OriginServiceAreaCode',
             'required' => false,
             'subobject' => false,
             'comment' => 'OriginServiceAreaCode',
             'maxLength' => '3',
-        ), 
+        ),
         'OriginFacilityCode' => array(
             'type' => 'OriginFacilityCode',
             'required' => false,
             'subobject' => false,
             'comment' => 'OriginFacilityCode',
             'maxLength' => '3',
-        ), 
+        ),
         'CountryCode' => array(
             'type' => 'CountryCode',
             'required' => false,
             'subobject' => false,
             'comment' => 'ISO country codes',
             'length' => '2',
-        ), 
+        ),
         'CountryName' => array(
             'type' => 'CountryName',
             'required' => false,
             'subobject' => false,
             'comment' => 'ISO country name',
             'maxLength' => '35',
-        ), 
+        ),
         'FederalTaxId' => array(
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'StateTaxId' => array(
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'Contact' => array(
             'type' => 'Contact',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
     );
 }

--- a/DHL/Datatype/AM/Shipper.php
+++ b/DHL/Datatype/AM/Shipper.php
@@ -68,7 +68,8 @@ class Shipper extends Base
             'required' => false,
             'subobject' => false,
             'comment' => 'Address Line',
-            'maxLength' => '35',
+            'maxLength' => '45',
+            'multivalues' => true,
         ),
         'City' => array(
             'type' => 'City',

--- a/DHL/Datatype/AM/Weight.php
+++ b/DHL/Datatype/AM/Weight.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Note : Code is released under the GNU LGPL
+ *
+ * Please do not change the header of this file
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU Lesser General Public License for more details.
+ */
+
+/**
+ * File:        WeightSeg.php
+ * Project:     DHL API
+ *
+ * @author      Al-Fallouji Bashar
+ * @version     0.1
+ */
+
+namespace DHL\Datatype\AM;
+use DHL\Datatype\Base;
+
+/**
+ * WeightSeg Request model for DHL API
+ */
+class Weight extends Base
+{
+    /**
+     * Is this object a subobject
+     * @var boolean
+     */
+    protected $_isSubobject = true;
+
+    /**
+     * Parameters of the datatype
+     * @var array
+     */
+    protected $_params = array(
+        'Weight' => array(
+            'type' => 'Weight',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'Weight of piece or shipment',
+            'fractionDigits' => '1',
+            'maxInclusive' => '999999.9',
+            'totalDigits' => '7',
+        ),
+        'WeightUnit' => array(
+            'type' => 'WeightUnit',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'Unit of weight measurement (L:Pounds)',
+            'length' => '1',
+            'enumeration' => 'K,L',
+        ),
+    );
+}

--- a/DHL/Datatype/AP/ExportDeclaration.php
+++ b/DHL/Datatype/AP/ExportDeclaration.php
@@ -22,7 +22,7 @@
  * @version     0.1
  */
 
-namespace DHL\Datatype\AP; 
+namespace DHL\Datatype\AP;
 use DHL\Datatype\Base;
 
 /**
@@ -45,7 +45,7 @@ class ExportDeclaration extends Base
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'IsPartiesRelation' => array(
             'type' => 'YesNo',
             'required' => false,
@@ -53,33 +53,33 @@ class ExportDeclaration extends Base
             'comment' => 'Boolean flag',
             'length' => '1',
             'enumeration' => 'Y,N',
-        ), 
+        ),
         'ECCN' => array(
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'SignatureName' => array(
             'type' => 'SignatureName',
             'required' => false,
             'subobject' => false,
             'comment' => 'Signature name',
             'maxLength' => '35',
-        ), 
+        ),
         'SignatureTitle' => array(
             'type' => 'SignatureTitle',
             'required' => false,
             'subobject' => false,
             'comment' => 'Signature title',
             'maxLength' => '35',
-        ), 
+        ),
         'ExportReason' => array(
             'type' => 'ExportReason',
             'required' => false,
             'subobject' => false,
             'comment' => 'Export reason',
             'length' => '1',
-        ), 
+        ),
         'ExportReasonCode' => array(
             'type' => 'ExportReasonCode',
             'required' => false,
@@ -87,14 +87,14 @@ class ExportDeclaration extends Base
             'comment' => 'Export reason code (P:Permanent, T:Temporary, R:Re-Export)',
             'length' => '1',
             'enumeration' => 'P,T,R',
-        ), 
+        ),
         'SedNumber' => array(
             'type' => 'SEDNumber',
             'required' => false,
             'subobject' => false,
             'comment' => '',
             'enumeration' => 'FTSR,XTN,SAS',
-        ), 
+        ),
         'SedNumberType' => array(
             'type' => 'SEDNumberType',
             'required' => false,
@@ -102,16 +102,16 @@ class ExportDeclaration extends Base
             'comment' => '',
             'length' => '1',
             'enumeration' => 'F,X,S',
-        ), 
+        ),
         'MxStateCode' => array(
             'type' => '',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'ExportLineItem' => array(
             'type' => 'ExportLineItem',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
     );
 }

--- a/DHL/Datatype/Base.php
+++ b/DHL/Datatype/Base.php
@@ -42,14 +42,14 @@ abstract class Base
     protected $_values = array();
 
     /**
-     * Parent node name of the object 
+     * Parent node name of the object
      * @var string
      */
     protected $_xmlNodeName = null;
 
     /**
      * Class constructor
-     */ 
+     */
     public function __construct()
     {
         $this->initializeValues();
@@ -57,17 +57,17 @@ abstract class Base
 
     /**
      * Check if current object is empty or not
-     * 
+     *
      * @return boolean True if it is, false otherwise
      */
     public function isEmpty()
     {
-        foreach ($this->_values as $k => $v) 
+        foreach ($this->_values as $k => $v)
         {
             if (is_object($v))
             {
-                if (!$v->isEmpty()) 
-                { 
+                if (!$v->isEmpty())
+                {
                     return false;
                 }
             }
@@ -82,9 +82,9 @@ abstract class Base
 
     /**
      * Generates the XML to be sent to DHL
-     * 
+     *
      * @param \XMLWriter $xmlWriter XMl Writer instance
-     * 
+     *
      * @return void
      */
     public function toXML(\XMLWriter $xmlWriter = null)
@@ -97,7 +97,7 @@ abstract class Base
         $displayedParentNode = false;
         $this->validateParameters();
 
-        if (null !== $this->_xmlNodeName) 
+        if (null !== $this->_xmlNodeName)
         {
             $parentNode = $this->_xmlNodeName;
         }
@@ -109,15 +109,15 @@ abstract class Base
 
         $xmlWriter->startElement($parentNode);
 
-        foreach ($this->_params as $name => $infos) 
+        foreach ($this->_params as $name => $infos)
         {
-            if ($this->$name) 
+            if ($this->$name)
             {
-                if (is_object($this->$name)) 
+                if (is_object($this->$name))
                 {
                     $this->$name->toXML($xmlWriter);
                 }
-                elseif (is_array($this->$name)) 
+                elseif (is_array($this->$name))
                 {
                     if ('string' == $this->_params[$name]['type'])
                     {
@@ -128,18 +128,18 @@ abstract class Base
                     }
                     else
                     {
-                        if (!isset($this->_params[$name]['disableParentNode']) || false == $this->_params[$name]['disableParentNode']) 
-                        {              
+                        if (!isset($this->_params[$name]['disableParentNode']) || false == $this->_params[$name]['disableParentNode'])
+                        {
                             $xmlWriter->startElement($name);
                         }
 
-                        foreach ($this->$name as $subelement) 
+                        foreach ($this->$name as $subelement)
                         {
                             $subelement->toXML($xmlWriter);
                         }
 
-                        if (!isset($this->_params[$name]['disableParentNode']) || false == $this->_params[$name]['disableParentNode']) 
-                        {              
+                        if (!isset($this->_params[$name]['disableParentNode']) || false == $this->_params[$name]['disableParentNode'])
+                        {
                             $xmlWriter->endElement();
                         }
                     }
@@ -156,18 +156,18 @@ abstract class Base
 
     /**
      * Initialize object from an XML string
-     * 
+     *
      * @param string $xml XML String
-     * 
+     *
      * @return void
      */
-    public function initFromXML($xml) 
+    public function initFromXML($xml)
     {
         $xml = simplexml_load_string(str_replace('req:', '', $xml));
         $parts = explode('\\', get_class($this));
         $className = array_pop($parts);
-        foreach ($xml->children() as $child) 
-        {           
+        foreach ($xml->children() as $child)
+        {
             $childName = $child->getName();
 
             if (isset($this->$childName) && is_object($this->$childName))
@@ -176,7 +176,7 @@ abstract class Base
             }
             elseif (isset($this->_params[$childName]['multivalues']) && $this->_params[$childName]['multivalues'])
             {
-                foreach ($child->children() as $subchild) 
+                foreach ($child->children() as $subchild)
                 {
                     $subchildName = $subchild->getName();
                     $childClassname = implode('\\', $parts) . '\\' . $this->_params[$subchildName]['type'];
@@ -203,20 +203,20 @@ abstract class Base
 
     /**
      * Setter for multivalues field
-     * 
+     *
      * @param string $key Key to set
      * @param mixed $value Value to set
-     * 
+     *
      * @return void
      * @throws \InvalidArgumentException Throws exception if key is not valid
      */
-    public function __call($name, $arguments) 
+    public function __call($name, $arguments)
     {
         $key = str_replace('add', '', $name);
 
-        if (isset($this->_params[$key . 's']) 
-            && $this->_params[$key . 's']['type'] != 'string' 
-            && isset($this->_params[$key. 's']['multivalues']) 
+        if (isset($this->_params[$key . 's'])
+            && $this->_params[$key . 's']['type'] != 'string'
+            && isset($this->_params[$key. 's']['multivalues'])
             && true === $this->_params[$key . 's']['multivalues'])
         {
             $key .= 's';
@@ -227,14 +227,14 @@ abstract class Base
             throw new \InvalidArgumentException('Field : ' . $key . ' is not defined for ' . get_class($this));
         }
 
-        if (empty($arguments) && count($arguments) > 1) 
+        if (empty($arguments) && count($arguments) > 1)
         {
             throw new \InvalidArgumentException($name . ' method takes only 1 argument');
         }
 
         $this->validateParameterType($key, $arguments[0]);
         $this->validateParameterValue($key, $arguments[0]);
-        
+
         if (isset($this->_params[$key]['multivalues']) && $this->_params[$key]['multivalues'])
         {
             $this->_values[$key][] = $arguments[0];
@@ -244,28 +244,28 @@ abstract class Base
             throw new \InvalidArgumentException('This is not a multivalues field : ' . $key . ' called via method ' . $name);
         }
     }
- 
+
     /**
      * Magic isset function
-     * 
+     *
      * @param string $key Key to check
-     * 
-     * @return bolean True if it exsits, false otherwise 
+     *
+     * @return bolean True if it exsits, false otherwise
      */
-    final public function __isset($key) 
+    final public function __isset($key)
     {
         return array_key_exists($key, $this->_values);
     }
 
     /**
      * Magic getter function
-     * 
+     *
      * @param string $key Key to get
-     * 
-     * @return mixed Value of the property 
+     *
+     * @return mixed Value of the property
      * @throws \InvalidArgumentException Throws exceptin if key is not valid
      */
-    final public function __get($key) 
+    final public function __get($key)
     {
         if (!array_key_exists($key, $this->_values))
         {
@@ -277,14 +277,14 @@ abstract class Base
 
     /**
      * Magic setter function
-     * 
+     *
      * @param string $key Key to set
      * @param mixed $value Value to set
-     * 
+     *
      * @return void
      * @throws \InvalidArgumentException Throws exception if key is not valid
      */
-    final public function __set($key, $value) 
+    final public function __set($key, $value)
     {
         if (!array_key_exists($key, $this->_values))
         {
@@ -295,7 +295,7 @@ abstract class Base
         $this->validateParameterValue($key, $value);
         $this->_values[$key] = $value;
     }
- 
+
     /**
      * Initialize property values bag
      *
@@ -303,9 +303,9 @@ abstract class Base
      */
     protected function initializeValues()
     {
-        foreach ($this->_params as $name => $infos) 
+        foreach ($this->_params as $name => $infos)
         {
-            if (isset($infos['multivalues']) && $infos['multivalues']) 
+            if (isset($infos['multivalues']) && $infos['multivalues'])
             {
                 $this->_values[$name] = array();
             }
@@ -326,24 +326,24 @@ abstract class Base
 
     /**
      * Validate all parameters
-     * 
+     *
      * @return boolean True upon success
      * @throws \InvalidArgumentException Throws exception if type not valid or if value are missing
      */
     protected function validateParameters()
     {
-        foreach ($this->_params as $name => $infos) 
+        foreach ($this->_params as $name => $infos)
         {
-            if ($this->_values[$name]) 
+            if ($this->_values[$name])
             {
-                if (is_array($this->_values[$name]) && isset($infos['subobject']) && true === $infos['subobject']) 
+                if (is_array($this->_values[$name]) && isset($infos['subobject']) && true === $infos['subobject'])
                 {
                     foreach ($this->_values[$name] as $subelement)
                     {
                         $subelement->validateParameters();
                     }
                 }
-                else 
+                else
                 {
                     $this->validateParameterType($name, $this->_values[$name]);
                     $this->validateParameterValue($name, $this->_values[$name]);
@@ -356,37 +356,37 @@ abstract class Base
 
     /**
      * Validate the type of a parameter
-     * 
+     *
      * @param string $key Key to check
      * @param mixed $value Value to check
-     * 
+     *
      * @return boolean True upon success
      * @throws \InvalidArgumentException Throws exception if type is not valid
      */
     protected function validateParameterType($key, $value)
     {
-        if (null === $value) 
+        if (null === $value)
         {
             return true;
         }
 
-        switch ($this->_params[$key]['type']) 
+        switch ($this->_params[$key]['type'])
         {
             case 'string':
-                if (is_array($value) && isset($this->_params[$key]['multivalues']) && true === $this->_params[$key]['multivalues']) 
+                if (is_array($value) && isset($this->_params[$key]['multivalues']) && true === $this->_params[$key]['multivalues'])
                 {
-                    foreach ($value as $subvalue) 
+                    foreach ($value as $subvalue)
                     {
-                        if (null !== $subvalue && $subvalue !== (string) $subvalue) 
+                        if (null !== $subvalue && $subvalue !== (string) $subvalue)
                         {
-                            throw new \InvalidArgumentException('Invalid type for ' . $key . '. It should be of type : ' 
+                            throw new \InvalidArgumentException('Invalid type for ' . $key . '. It should be of type : '
                                 . $this->_params[$key]['type'] . ' but it has a value of : ' . $subvalue);
                         }
                     }
                 }
                 elseif ($value !== (string) $value)
                 {
-                    throw new \InvalidArgumentException('Invalid type for ' . $key . '. It should be of type : ' 
+                    throw new \InvalidArgumentException('Invalid type for ' . $key . '. It should be of type : '
                         . $this->_params[$key]['type'] . ' but it has a value of : ' . $value);
                 }
             break;
@@ -397,7 +397,7 @@ abstract class Base
                 $date = date(DATE_ISO8601, $timestamp);
                 if (strtotime($date) !== strtotime($value))
                 {
-                    throw new \InvalidArgumentException('Invalid type for ' . $key . '. It should be of type : ' 
+                    throw new \InvalidArgumentException('Invalid type for ' . $key . '. It should be of type : '
                         . $this->_params[$key]['type'] . ' but it has a value of : ' . $value);
                 }
             break;
@@ -405,9 +405,9 @@ abstract class Base
             case 'positiveInteger':
             case 'negativeInteger':
             case 'integer':
-                 if (false === filter_var((int) $value, FILTER_VALIDATE_INT) && ((int) $value != $value)) 
+                 if (false === filter_var((int) $value, FILTER_VALIDATE_INT) && ((int) $value != $value))
                  {
-                     throw new \InvalidArgumentException('Invalid type for ' . $key . '. It should be of type : ' 
+                     throw new \InvalidArgumentException('Invalid type for ' . $key . '. It should be of type : '
                         . $this->_params[$key]['type'] . ' but it has a value of : ' . $value);
                  }
             break;
@@ -421,7 +421,7 @@ abstract class Base
                     $className = str_replace('Entity', 'DataType', implode('\\', $parts) . '\\' . $this->_params[$key]['type']);
                     if (!$value instanceof $className)
                     {
-                        throw new \InvalidArgumentException('Invalid type for ' . $key . '. It should be of type : ' 
+                        throw new \InvalidArgumentException('Invalid type for ' . $key . '. It should be of type : '
                             . $this->_params[$key]['type'] . ' but it has a value of : "' . print_r($value, true) . '"');
                     }
                 }
@@ -433,27 +433,27 @@ abstract class Base
 
     /**
      * Validate the value of a parameter
-     * 
+     *
      * @param string $key Key to check
      * @param mixed $value Value to check
-     * 
+     *
      * @return boolean True upon success
      * @throws \InvalidArgumentException Throws exception if value is not valid
      */
     protected function validateParameterValue($key, $value)
     {
-        foreach ($this->_params[$key] as $type => $typeValue) 
+        foreach ($this->_params[$key] as $type => $typeValue)
         {
-            switch ($type) 
+            switch ($type)
             {
                 case 'enumeration':
                     $acceptedValues = explode(',', $typeValue);
-                    if (!in_array($value, $acceptedValues)) 
+                    if (!in_array($value, $acceptedValues))
                     {
                         throw new \InvalidArgumentException('Field ' . $key . ' cannot be set to value : ' . $value . '. Accepted values are : ' . $typeValue);
                     }
                 break;
-           
+
                 case 'length':
                     if (strlen($value) != $typeValue)
                     {
@@ -474,14 +474,14 @@ abstract class Base
                         throw new \InvalidArgumentException('Field ' . $key . ' has a size of ' . strlen($value) . ' and it cannot be less than this size : ' . $typeValue);
                     }
                 break;
- 
+
                 case 'minInclusive':
                     if ($value < $typeValue)
                     {
                         throw new \InvalidArgumentException('Field ' . $key . ' cannot be smaller than ' . $typeValue);
                     }
                 break;
- 
+
                 case 'maxInclusive':
                     if ($value > $typeValue)
                     {
@@ -492,7 +492,7 @@ abstract class Base
                 case 'pattern':
                     $matches = array();
                     $typeValue = "/" . $typeValue . "/";
-                    if (1 !== preg_match($typeValue, $value, $matches) || (strlen($value) > 0 && !$matches[0])) 
+                    if (1 !== preg_match($typeValue, $value, $matches) || (strlen($value) > 0 && !$matches[0]))
                     {
                         throw new \InvalidArgumentException('Field ' . $key . ' should match regex pattern : ' . $typeValue . ' and it has a value of ' . $value);
                     }

--- a/DHL/Datatype/Base.php
+++ b/DHL/Datatype/Base.php
@@ -462,9 +462,18 @@ abstract class Base
                 break;
 
                 case 'maxLength':
-                    if (strlen($value) > $typeValue)
-                    {
-                        throw new \InvalidArgumentException('Field ' . $key . ' has a size of ' . strlen($value) . ' and it cannot exceed this size : ' . $typeValue);
+                    if ( is_array( $value ) ) {
+                        foreach( $value as $item ) {
+                            if ( strlen( $item ) > $typeValue ) {
+                                throw new \InvalidArgumentException( 'Field ' . $key . ' has a size of ' . strlen( $item ) . ' and it cannot exceed this size : ' . $typeValue );
+                            }
+                        }
+                    }
+                    else {
+                        if (strlen($value) > $typeValue)
+                        {
+                            throw new \InvalidArgumentException('Field ' . $key . ' has a size of ' . strlen($value) . ' and it cannot exceed this size : ' . $typeValue);
+                        }
                     }
                 break;
 

--- a/DHL/Entity/AM/BookPickupRequest.php
+++ b/DHL/Entity/AM/BookPickupRequest.php
@@ -22,7 +22,7 @@
  * @version     0.1
  */
 
-namespace DHL\Entity\AM; 
+namespace DHL\Entity\AM;
 use DHL\Entity\Base;
 
 /**
@@ -40,13 +40,25 @@ class BookPickupRequest extends Base
      * Name of the service
      * @var string
      */
-    protected $_serviceName = 'BookPickupRequest';
+    protected $_serviceName = 'BookPURequest';
 
     /**
      * @var string
      * Service XSD
      */
-    protected $_serviceXSD = 'BookPickupRequest.xsd';
+    protected $_serviceXSD = 'pickup-global-req.xsd';
+
+    /**
+     * @var string
+     * The schema version
+     */
+    protected $_schemaVersion = '3.0';
+
+    /**
+     * Display the schema version
+     * @var boolean
+     */
+    protected $_displaySchemaVersion = true;
 
     /**
      * Parameters to be send in the body
@@ -54,39 +66,34 @@ class BookPickupRequest extends Base
      */
     protected $_bodyParams = array(
         'Requestor' => array(
-            'type' => 'string',
-            'required' => false,
-            'subobject' => false,
-        ), 
-        'Place' => array(
-            'type' => 'Place',
-            'required' => false,
+            'type' => 'Requestor',
+            'required' => true,
             'subobject' => true,
-        ), 
+        ),
+        'Place' => array(
+            'type' => 'PickupPlace',
+            'required' => true,
+            'subobject' => true,
+        ),
         'Pickup' => array(
-            'type' => 'string',
-            'required' => false,
-            'subobject' => false,
-        ), 
+            'type' => 'Pickup',
+            'required' => true,
+            'subobject' => true,
+        ),
         'PickupContact' => array(
-            'type' => 'string',
-            'required' => false,
-            'subobject' => false,
-        ), 
-        'ShipmentDetails' => array(
+            'type' => 'PickupContact',
+            'required' => true,
+            'subobject' => true,
+        ),
+        'ShipmentDetails' => array( // TODO: check datatype class parameters
             'type' => 'ShipmentDetails',
             'required' => false,
             'subobject' => true,
-        ), 
-        'PickupType' => array(
-            'type' => 'string',
+        ),
+        'ConsigneeDetails' => array( // TODO: make datatype class
+            'type' => 'ConsigneeDetails',
             'required' => false,
             'subobject' => false,
-        ), 
-        'LargestPiece' => array(
-            'type' => 'string',
-            'required' => false,
-            'subobject' => false,
-        ), 
+        ),
     );
 }

--- a/DHL/Entity/AM/GetQuote.php
+++ b/DHL/Entity/AM/GetQuote.php
@@ -22,7 +22,7 @@
  * @version     0.1
  */
 
-namespace DHL\Entity\AM; 
+namespace DHL\Entity\AM;
 use DHL\Entity\Base;
 
 /**
@@ -43,10 +43,23 @@ class GetQuote extends Base
     protected $_serviceXSD = 'DCT-req.xsd';
 
     /**
-     * Parent node name of the object 
+     * Parent node name of the object
      * @var string
      */
     protected $_xmlNodeName = 'GetQuote';
+
+    /**
+     * @var string
+     * The schema version
+     */
+    protected $_schemaVersion = '6.2';
+
+    /**
+     * Display the schema version
+     * @var boolean
+     */
+    protected $_displaySchemaVersion = true;
+
 
     /**
      * Parameters to be send in the body
@@ -59,27 +72,27 @@ class GetQuote extends Base
             'subobject' => true,
             'multivalues' => false,
             'minOccurs' => 1,
-        ), 
+        ),
         'BkgDetails' => array(
             'type' => 'BkgDetailsType',
             'required' => false,
             'subobject' => true,
             'multivalues' => false,
             'minOccurs' => 1,
-        ), 
+        ),
         'To' => array(
             'type' => 'DCTTo',
             'required' => false,
             'subobject' => true,
             'multivalues' => false,
             'minOccurs' => 1,
-        ), 
+        ),
         'Dutiable' => array(
             'type' => 'DCTDutiable',
             'required' => false,
             'subobject' => true,
             'multivalues' => false,
             'minOccurs' => 0,
-        ), 
+        ),
    );
 }

--- a/DHL/Entity/AM/GetQuote.php
+++ b/DHL/Entity/AM/GetQuote.php
@@ -52,7 +52,7 @@ class GetQuote extends Base
      * @var string
      * The schema version
      */
-    protected $_schemaVersion = '6.2';
+    protected $_schemaVersion = '1.0';
 
     /**
      * Display the schema version

--- a/DHL/Entity/AM/ShipmentRequest.php
+++ b/DHL/Entity/AM/ShipmentRequest.php
@@ -15,7 +15,7 @@
  */
 
 /**
- * File:        ShipmentValidateRequest.php
+ * File:        ShipmentRequest.php
  * Project:     DHL API
  *
  * @author      Al-Fallouji Bashar
@@ -26,9 +26,9 @@ namespace DHL\Entity\AM;
 use DHL\Entity\Base;
 
 /**
- * ShipmentValidateRequest Request model for DHL API
+ * ShipmentRequest Request model for DHL API
  */
-class ShipmentValidateRequest extends Base
+class ShipmentRequest extends Base
 {
     /**
      * Is this object a subobject
@@ -40,13 +40,13 @@ class ShipmentValidateRequest extends Base
      * Name of the service
      * @var string
      */
-    protected $_serviceName = 'ShipmentValidateRequest';
+    protected $_serviceName = 'ShipmentRequest';
 
     /**
      * @var string
      * Service XSD
      */
-    protected $_serviceXSD = 'ShipmentValidateRequest.xsd';
+    protected $_serviceXSD = 'ShipmentRequest.xsd';
 
     /**
      * @var string

--- a/DHL/Entity/AM/ShipmentValidateRequest.php
+++ b/DHL/Entity/AM/ShipmentValidateRequest.php
@@ -22,7 +22,7 @@
  * @version     0.1
  */
 
-namespace DHL\Entity\AM; 
+namespace DHL\Entity\AM;
 use DHL\Entity\Base;
 
 /**
@@ -57,90 +57,90 @@ class ShipmentValidateRequest extends Base
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'NewShipper' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'LanguageCode' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
             'comment' => 'ISO Language Code',
-        ), 
+        ),
         'PiecesEnabled' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
             'comment' => 'Pieces Enabling Flag',
             'enumeration' => 'Y,N',
-        ), 
+        ),
         'Billing' => array(
             'type' => 'Billing',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Consignee' => array(
             'type' => 'Consignee',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Commodity' => array(
             'type' => 'Commodity',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Dutiable' => array(
             'type' => 'Dutiable',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'ExportDeclaration' => array(
             'type' => 'ExportDeclaration',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Reference' => array(
             'type' => 'Reference',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'ShipmentDetails' => array(
             'type' => 'ShipmentDetails',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Shipper' => array(
             'type' => 'Shipper',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'SpecialService' => array(
             'type' => 'SpecialService',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Place' => array(
             'type' => 'Place',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'EProcShip' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'Airwaybill' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'DocImages' => array(
             'type' => 'DocImages',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'LabelImageFormat' => array(
             'type' => 'string',
             'required' => false,
@@ -149,16 +149,31 @@ class ShipmentValidateRequest extends Base
             'minLength' => '3',
             'maxLength' => '4',
             'enumeration' => 'PDF,ZPL2,EPL2',
-        ), 
+        ),
         'RequestArchiveDoc' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'Label' => array(
             'type' => 'Label',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
+        'UseDHLInvoice' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+        ),
+        'DHLInvoiceLanguageCode' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+        ),
+        'DHLInvoiceType' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+        ),
     );
 }

--- a/DHL/Entity/AM/ShipmentValidateRequest.php
+++ b/DHL/Entity/AM/ShipmentValidateRequest.php
@@ -65,6 +65,15 @@ class ShipmentValidateRequest extends Base
      * @var array
      */
     protected $_bodyParams = array(
+        'RegionCode' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'RegionCode',
+            'minLength' => '2',
+            'maxLength' => '2',
+            'enumeration' => 'AP,EU,AM',
+        ),
         'RequestedPickupTime' => array(
             'type' => 'string',
             'required' => false,
@@ -107,6 +116,21 @@ class ShipmentValidateRequest extends Base
             'type' => 'Dutiable',
             'required' => false,
             'subobject' => true,
+        ),
+        'UseDHLInvoice' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+        ),
+        'DHLInvoiceLanguageCode' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+        ),
+        'DHLInvoiceType' => array(
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
         ),
         'ExportDeclaration' => array(
             'type' => 'ExportDeclaration',
@@ -171,21 +195,6 @@ class ShipmentValidateRequest extends Base
             'type' => 'Label',
             'required' => false,
             'subobject' => true,
-        ),
-        'UseDHLInvoice' => array(
-            'type' => 'string',
-            'required' => false,
-            'subobject' => false,
-        ),
-        'DHLInvoiceLanguageCode' => array(
-            'type' => 'string',
-            'required' => false,
-            'subobject' => false,
-        ),
-        'DHLInvoiceType' => array(
-            'type' => 'string',
-            'required' => false,
-            'subobject' => false,
         ),
     );
 }

--- a/DHL/Entity/AM/ShipmentValidateRequest.php
+++ b/DHL/Entity/AM/ShipmentValidateRequest.php
@@ -49,6 +49,18 @@ class ShipmentValidateRequest extends Base
     protected $_serviceXSD = 'ShipmentValidateRequest.xsd';
 
     /**
+     * @var string
+     * The schema version
+     */
+    protected $_schemaVersion = '6.2';
+
+    /**
+     * Display the schema version
+     * @var boolean
+     */
+    protected $_displaySchemaVersion = true;
+
+    /**
      * Parameters to be send in the body
      * @var array
      */

--- a/DHL/Entity/AP/ShipmentValidateRequest.php
+++ b/DHL/Entity/AP/ShipmentValidateRequest.php
@@ -15,18 +15,18 @@
  */
 
 /**
- * File:        ShipmentValidateRequest.php
+ * File:        ShipmentRequest.php
  * Project:     DHL API
  *
  * @author      Al-Fallouji Bashar
  * @version     0.1
  */
 
-namespace DHL\Entity\AP; 
+namespace DHL\Entity\AP;
 use DHL\Entity\Base;
 
 /**
- * ShipmentValidateRequest Request model for DHL API
+ * ShipmentRequest Request model for DHL API
  */
 class ShipmentValidateRequest extends Base
 {
@@ -58,74 +58,74 @@ class ShipmentValidateRequest extends Base
             'required' => false,
             'subobject' => false,
             'comment' => 'ISO Language Code',
-        ), 
+        ),
         'PiecesEnabled' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
             'comment' => 'Pieces Enabling Flag',
             'enumeration' => 'Y,N',
-        ), 
+        ),
         'Billing' => array(
             'type' => 'Billing',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Consignee' => array(
             'type' => 'Consignee',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Commodity' => array(
             'type' => 'Commodity',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Dutiable' => array(
             'type' => 'Dutiable',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'ExportDeclaration' => array(
             'type' => 'ExportDeclaration',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Reference' => array(
             'type' => 'Reference',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'ShipmentDetails' => array(
             'type' => 'ShipmentDetails',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Shipper' => array(
             'type' => 'Shipper',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'SpecialService' => array(
             'type' => 'SpecialService',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'EProcShip' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'Airwaybill' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'DocImages' => array(
             'type' => 'DocImages',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'LabelImageFormat' => array(
             'type' => 'string',
             'required' => false,
@@ -134,16 +134,16 @@ class ShipmentValidateRequest extends Base
             'minLength' => '3',
             'maxLength' => '4',
             'enumeration' => 'PDF,ZPL2,EPL2',
-        ), 
+        ),
         'RequestArchiveDoc' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'Label' => array(
             'type' => 'Label',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
     );
 }

--- a/DHL/Entity/Base.php
+++ b/DHL/Entity/Base.php
@@ -63,11 +63,26 @@ abstract class Base extends BaseDataType
         'Password' => array(
             'type' => 'string',
             'required' => true,
+        )
+    );
+
+    /**
+     * Parameters to be used in the MetaData Header
+     * @var array
+     */
+    protected $_metaDataParams = array(
+        'SoftwareName' => array(
+            'type' => 'string',
+            'required' => true,
+        ),
+        'SoftwareVersion' => array(
+            'type' => 'string',
+            'required' => true,
         ),
     );
 
     /**
-     * Parameters to be used in the body 
+     * Parameters to be used in the body
      * @var array
      */
     protected $_bodyParams = array();
@@ -103,7 +118,7 @@ abstract class Base extends BaseDataType
     protected $_displaySchemaVersion = false;
 
     /**
-     * Parent node name of the object 
+     * Parent node name of the object
      * @var string
      */
     protected $_xmlNodeName = null;
@@ -116,10 +131,10 @@ abstract class Base extends BaseDataType
 
     /**
      * Class constructor
-     */ 
+     */
     public function __construct()
     {
-        $this->_params = array_merge($this->_headerParams, $this->_bodyParams);
+        $this->_params = array_merge($this->_headerParams, $this->_metaDataParams, $this->_bodyParams);
         $this->initializeValues();
     }
 
@@ -127,7 +142,7 @@ abstract class Base extends BaseDataType
      * Generates the XML to be sent to DHL
      *
      * @param \XMLWriter $xmlWriter XMl Writer instance
-     *   
+     *
      * @return string
      */
     public function toXML(\XMLWriter $xmlWriter = null)
@@ -138,40 +153,47 @@ abstract class Base extends BaseDataType
         $xmlWriter->openMemory();
         $xmlWriter->setIndent(true);
         $xmlWriter->startDocument('1.0', 'UTF-8');
-            
+
         $xmlWriter->startElement('req:' . $this->_serviceName);
         $xmlWriter->writeAttribute('xmlns:req', self::DHL_REQ);
         $xmlWriter->writeAttribute('xmlns:xsi', self::DHL_XSI);
         $xmlWriter->writeAttribute('xsi:schemaLocation', self::DHL_REQ . ' ' .$this->_serviceXSD);
-    
-        if ($this->_displaySchemaVersion) 
+
+        if ($this->_displaySchemaVersion)
         {
             $xmlWriter->writeAttribute('schemaVersion', $this->_schemaVersion);
         }
 
-        if (null !== $this->_xmlNodeName) 
+        if (null !== $this->_xmlNodeName)
         {
             $xmlWriter->startElement($this->_xmlNodeName);
         }
 
         $xmlWriter->startElement('Request');
         $xmlWriter->startElement('ServiceHeader');
-        foreach ($this->_headerParams as $name => $infos) 
+        foreach ($this->_headerParams as $name => $infos)
         {
             $xmlWriter->writeElement($name, $this->$name);
         }
-        $xmlWriter->endElement(); // End of Request
         $xmlWriter->endElement(); // End of ServiceHeader
 
-        foreach ($this->_bodyParams as $name => $infos) 
+        $xmlWriter->startElement('MetaData');
+        foreach ($this->_metaDataParams as $name => $infos)
+        {
+            $xmlWriter->writeElement($name, $this->$name);
+        }
+        $xmlWriter->endElement(); // End of MetaData
+        $xmlWriter->endElement(); // End of Request
+
+        foreach ($this->_bodyParams as $name => $infos)
         {
             if ($this->$name)
             {
-                if (is_object($this->$name)) 
+                if (is_object($this->$name))
                 {
                     $this->$name->toXML($xmlWriter);
                 }
-                elseif (is_array($this->$name)) 
+                elseif (is_array($this->$name))
                 {
                     if ('string' == $this->_params[$name]['type'])
                     {
@@ -182,18 +204,18 @@ abstract class Base extends BaseDataType
                     }
                     else
                     {
-                        if (!isset($this->_params[$name]['disableParentNode']) || false == $this->_params[$name]['disableParentNode']) 
-                        {              
+                        if (!isset($this->_params[$name]['disableParentNode']) || false == $this->_params[$name]['disableParentNode'])
+                        {
                             $xmlWriter->startElement($name);
                         }
 
-                        foreach ($this->$name as $subelement) 
+                        foreach ($this->$name as $subelement)
                         {
                             $subelement->toXML($xmlWriter);
                         }
 
-                        if (!isset($this->_params[$name]['disableParentNode']) || false == $this->_params[$name]['disableParentNode']) 
-                        {              
+                        if (!isset($this->_params[$name]['disableParentNode']) || false == $this->_params[$name]['disableParentNode'])
+                        {
                             $xmlWriter->endElement();
                         }
                     }
@@ -208,25 +230,25 @@ abstract class Base extends BaseDataType
         $xmlWriter->endElement(); // End of parent node
 
         // End of class name tag
-        if (null !== $this->_xmlNodeName) 
+        if (null !== $this->_xmlNodeName)
         {
             $xmlWriter->endElement();
         }
 
         $xmlWriter->endDocument();
-    
+
         return $xmlWriter->outputMemory(true);
     }
 
     /**
      * Initialize object from an XML string
-     * 
+     *
      * @param string $xml XML String
-     * 
+     *
      * @return void
      * @throws \Exception Exception thrown if response returned has an error
      */
-    public function initFromXML($xml) 
+    public function initFromXML($xml)
     {
         $xml = simplexml_load_string(str_replace('req:', '', $xml));
 
@@ -238,8 +260,8 @@ abstract class Base extends BaseDataType
 
         $parts = explode('\\', get_class($this));
         $className = array_pop($parts);
-        foreach ($xml->children() as $child) 
-        {           
+        foreach ($xml->children() as $child)
+        {
             $childName = $child->getName();
             switch ($childName)
             {
@@ -257,7 +279,7 @@ abstract class Base extends BaseDataType
                     }
                     elseif (isset($this->_params[$childName]['multivalues']) && $this->_params[$childName]['multivalues'])
                     {
-                        foreach ($child->children() as $subchild) 
+                        foreach ($child->children() as $subchild)
                         {
                             $subchildName = $subchild->getName();
                             if ($subchild->count() > 1)
@@ -277,7 +299,7 @@ abstract class Base extends BaseDataType
                                 $childObj = new $childClassname();
                                 $childObj->initFromXml($subchild->asXML());
                             }
-                            
+
                             $addMethodName = 'add' . ucfirst($subchildName);
                             $this->$addMethodName($childObj);
                         }
@@ -297,11 +319,11 @@ abstract class Base extends BaseDataType
      */
     protected function initializeValues()
     {
-        foreach ($this->_params as $name => $infos) 
+        foreach ($this->_params as $name => $infos)
         {
             if (!$this->_isSubobject && isset($infos['subobject']) && $infos['subobject'])
             {
-                if (isset($infos['multivalues']) && $infos['multivalues']) 
+                if (isset($infos['multivalues']) && $infos['multivalues'])
                 {
                     $this->_values[$name] = array();
                 }
@@ -324,29 +346,29 @@ abstract class Base extends BaseDataType
 
     /**
      * Validate all parameters
-     * 
+     *
      * @return boolean True upon success
      * @throws \InvalidArgumentException Throws exception if type not valid or if value are missing
      */
     protected function validateParameters()
     {
-        foreach ($this->_params as $name => $infos) 
+        foreach ($this->_params as $name => $infos)
         {
             if (isset($infos['required']) && true === $infos['required'] && $this->_values[$name] === null)
             {
                 throw new \InvalidArgumentException('Field ' . $name . ' has no value');
             }
 
-            if ($this->_values[$name]) 
+            if ($this->_values[$name])
             {
-                if (is_array($this->_values[$name])) 
+                if (is_array($this->_values[$name]))
                 {
                     foreach ($this->_values[$name] as $subelement)
                     {
                         $subelement->validateParameters();
                     }
                 }
-                else 
+                else
                 {
                     $this->validateParameterType($name, $this->_values[$name]);
                     $this->validateParameterValue($name, $this->_values[$name]);

--- a/DHL/Entity/EA/ShipmentValidateRequest.php
+++ b/DHL/Entity/EA/ShipmentValidateRequest.php
@@ -15,18 +15,18 @@
  */
 
 /**
- * File:        ShipmentValidateRequest.php
+ * File:        ShipmentRequest.php
  * Project:     DHL API
  *
  * @author      Al-Fallouji Bashar
  * @version     0.1
  */
 
-namespace DHL\Entity\EA; 
+namespace DHL\Entity\EA;
 use DHL\Entity\Base;
 
 /**
- * ShipmentValidateRequest Request model for DHL API
+ * ShipmentRequest Request model for DHL API
  */
 class ShipmentValidateRequest extends Base
 {
@@ -57,85 +57,85 @@ class ShipmentValidateRequest extends Base
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'LanguageCode' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
             'comment' => 'ISO Language Code',
-        ), 
+        ),
         'PiecesEnabled' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
             'comment' => 'Pieces Enabling Flag',
             'enumeration' => 'Y,N',
-        ), 
+        ),
         'Billing' => array(
             'type' => 'Billing',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Consignee' => array(
             'type' => 'Consignee',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Commodity' => array(
             'type' => 'Commodity',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Dutiable' => array(
             'type' => 'Dutiable',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'ExportDeclaration' => array(
             'type' => 'ExportDeclaration',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Reference' => array(
             'type' => 'Reference',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'ShipmentDetails' => array(
             'type' => 'ShipmentDetails',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Shipper' => array(
             'type' => 'Shipper',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'SpecialService' => array(
             'type' => 'SpecialService',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'Place' => array(
             'type' => 'Place',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'EProcShip' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'Airwaybill' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'DocImages' => array(
             'type' => 'DocImages',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
         'LabelImageFormat' => array(
             'type' => 'string',
             'required' => false,
@@ -144,16 +144,16 @@ class ShipmentValidateRequest extends Base
             'minLength' => '3',
             'maxLength' => '4',
             'enumeration' => 'PDF,ZPL2,EPL2',
-        ), 
+        ),
         'RequestArchiveDoc' => array(
             'type' => 'string',
             'required' => false,
             'subobject' => false,
-        ), 
+        ),
         'Label' => array(
             'type' => 'Label',
             'required' => false,
             'subobject' => true,
-        ), 
+        ),
     );
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mutahhar/dhl-api",
+    "name": "alfallouji/dhl_api",
 
     "description": "PHP library to communicate with the DHL XML Services.",
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "alfallouji/dhl_api",
+    "name": "mutahhar/dhl-api",
 
     "description": "PHP library to communicate with the DHL XML Services.",
 
@@ -9,11 +9,11 @@
 
     "license": "LGPL-2.1",
 
-	"autoload": {
+    "autoload": {
         "classmap" : [ "DHL" ]
-	},
+    },
 
-	"authors": [
+    "authors": [
         {
             "name": "Bashar Al-Fallouji",
             "email": "bashar@alfallouji.com"


### PR DESCRIPTION
- If someone now wants to generate a commercial invoice from DHL along with Label, he can now do it.
- Commercial Invoice related fields have been added to AM\ShipmentRequest.
- MetaData element values also added in the Request element of AM\ShipmentRequest along with the ServiceHeader element.
- Also, fixed some request parameters due to DHL API response errors.